### PR TITLE
57139  Changed topic filter matching to report metrics for all matching filters instead of just the first one.

### DIFF
--- a/transitdata-metrics-exporter/grafana/mqtt-dashboard.json
+++ b/transitdata-metrics-exporter/grafana/mqtt-dashboard.json
@@ -1,0 +1,860 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*hsl-mqtt-lab-d.*\", topic_filter=\"/hfp/v2/journey/ongoing/apc/#\"}[$__rate_interval])",
+          "legendFormat": "APC",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "hsl-mqtt-lab-d: /hfp/v2/journey/ongoing/apc/#",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*mqtt\\\\.hsl\\\\.fi.*\", topic_filter=\"/hfp/v2/journey/#\"}[$__rate_interval])",
+          "legendFormat": "HFP Journey",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "mqtt.hsl.fi: /hfp/v2/journey/#",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*mqtt\\\\.hsl\\\\.fi.*\", topic_filter=\"/hfp/v2/journey/ongoing/+/+/+/+/7280/#\"}[$__rate_interval])",
+          "legendFormat": "Route 7280",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "mqtt.hsl.fi: /hfp/v2/journey/ongoing/+/+/+/+/7280/#",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*mqtt\\\\.hsl\\\\.fi.*\", topic_filter=\"/hfp/v2/journey/ongoing/+/ferry/#\"}[$__rate_interval])",
+          "legendFormat": "Ferry",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "mqtt.hsl.fi: /hfp/v2/journey/ongoing/+/ferry/#",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*mqtt\\\\.hsl\\\\.fi.*\", topic_filter=\"/hfp/v2/journey/ongoing/+/metro/#\"}[$__rate_interval])",
+          "legendFormat": "Metro",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "mqtt.hsl.fi: /hfp/v2/journey/ongoing/+/metro/#",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*pred\\\\.rt\\\\.hsl\\\\.fi.*\", topic_filter=\"gtfsrt/v2/fi/hsl/tu\"}[$__rate_interval])",
+          "legendFormat": "Trip Updates",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "pred.rt.hsl.fi: gtfsrt/v2/fi/hsl/tu",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*test91\\\\.rt\\\\.hsl\\\\.fi.*\", topic_filter=\"gtfsrt/dev/fi/hsl/sa\"}[$__rate_interval])",
+          "legendFormat": "Service Alerts",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "test91.rt.hsl.fi: gtfsrt/dev/fi/hsl/sa",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*test91\\\\.rt\\\\.hsl\\\\.fi.*\", topic_filter=\"gtfsrt/dev/fi/hsl/tu\"}[$__rate_interval])",
+          "legendFormat": "Trip Updates",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "test91.rt.hsl.fi: gtfsrt/dev/fi/hsl/tu",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "msg/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "rate(mqtt_messages_received_total{broker=~\".*transitdata-dev-mqtt-broker.*\", topic_filter=\"gtfsrt/dev/fi/hsl/vp/#\"}[$__rate_interval])",
+          "legendFormat": "Vehicle Positions",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "transitdata-dev-mqtt: gtfsrt/dev/fi/hsl/vp/#",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["mqtt", "transitdata"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "MQTT Message Counts",
+  "uid": "mqtt-message-counts",
+  "version": 1
+}

--- a/transitdata-metrics-exporter/src/main/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicFilterMatcher.java
+++ b/transitdata-metrics-exporter/src/main/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicFilterMatcher.java
@@ -1,16 +1,18 @@
 package fi.hsl.transitdata.monitoring.mqtt;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.List;
 
 public class MqttTopicFilterMatcher {
 
-    public static Optional<String> findMatchingTopicFilter(String topic, String[] topicFilters) {
+    public static List<String> findMatchingTopicFilters(String topic, String[] topicFilters) {
+        var matches = new ArrayList<String>();
         for (var topicFilter : topicFilters) {
             if (topicMatches(topic, topicFilter)) {
-                return Optional.of(topicFilter);
+                matches.add(topicFilter);
             }
         }
-        return Optional.empty();
+        return matches;
     }
 
     private static boolean topicMatches(String topic, String topicFilter) {

--- a/transitdata-metrics-exporter/src/main/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicMonitorListener.java
+++ b/transitdata-metrics-exporter/src/main/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicMonitorListener.java
@@ -18,7 +18,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import static fi.hsl.transitdata.monitoring.mqtt.MqttTopicFilterMatcher.findMatchingTopicFilter;
+import static fi.hsl.transitdata.monitoring.mqtt.MqttTopicFilterMatcher.findMatchingTopicFilters;
 
 public class MqttTopicMonitorListener implements MqttCallbackExtended, Closeable {
 
@@ -98,15 +98,22 @@ public class MqttTopicMonitorListener implements MqttCallbackExtended, Closeable
 
     @Override
     public void messageArrived(String topic, MqttMessage message) {
-        Counter.builder("mqtt_messages_received_total")
-                .description("Total MQTT messages received")
-                .tag("broker", brokerAddress)
-                .tag("topic_filter", findMatchingTopicFilter(topic, topicFilters).orElse("unknown"))
-                .tag("qos", String.valueOf(message.getQos()))
-                .tag("is_duplicate", String.valueOf(message.isDuplicate()))
-                .tag("is_retained", String.valueOf(message.isRetained()))
-                .register(registry)
-                .increment();
+        var matchingFilters = findMatchingTopicFilters(topic, topicFilters);
+        if (matchingFilters.isEmpty()) {
+            matchingFilters = List.of("unknown");
+        }
+
+        for (var topicFilter : matchingFilters) {
+            Counter.builder("mqtt_messages_received_total")
+                    .description("Total MQTT messages received")
+                    .tag("broker", brokerAddress)
+                    .tag("topic_filter", topicFilter)
+                    .tag("qos", String.valueOf(message.getQos()))
+                    .tag("is_duplicate", String.valueOf(message.isDuplicate()))
+                    .tag("is_retained", String.valueOf(message.isRetained()))
+                    .register(registry)
+                    .increment();
+        }
     }
 
     @Override

--- a/transitdata-metrics-exporter/src/test/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicFilterMatcherTest.java
+++ b/transitdata-metrics-exporter/src/test/java/fi/hsl/transitdata/monitoring/mqtt/MqttTopicFilterMatcherTest.java
@@ -2,6 +2,7 @@ package fi.hsl.transitdata.monitoring.mqtt;
 
 import org.junit.jupiter.api.Test;
 
+import static fi.hsl.transitdata.monitoring.mqtt.MqttTopicFilterMatcher.findMatchingTopicFilters;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MqttTopicFilterMatcherTest {
@@ -13,10 +14,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"gtfsrt/v2/fi/hsl/tu"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("gtfsrt/v2/fi/hsl/tu");
+        assertThat(result).containsExactly("gtfsrt/v2/fi/hsl/tu");
     }
 
     @Test
@@ -26,10 +27,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/#");
     }
 
     @Test
@@ -39,10 +40,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/apc/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/apc/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/apc/#");
     }
 
     @Test
@@ -52,10 +53,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/ferry/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/+/ferry/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/+/ferry/#");
     }
 
     @Test
@@ -65,10 +66,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/metro/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/+/metro/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/+/metro/#");
     }
 
     @Test
@@ -78,10 +79,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/+/+/+/7280/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/+/+/+/+/7280/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/+/+/+/+/7280/#");
     }
 
     @Test
@@ -91,10 +92,10 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"gtfsrt/dev/fi/hsl/vp/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("gtfsrt/dev/fi/hsl/vp/#");
+        assertThat(result).containsExactly("gtfsrt/dev/fi/hsl/vp/#");
     }
 
     @Test
@@ -104,24 +105,24 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"gtfsrt/dev/fi/hsl/sa"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("gtfsrt/dev/fi/hsl/sa");
+        assertThat(result).containsExactly("gtfsrt/dev/fi/hsl/sa");
     }
 
     @Test
-    void shouldReturnFirstMatchingFilterFromMultiple() {
-        // given
+    void shouldReturnAllMatchingFilters() {
+        // given - ferry topic matches both the general journey filter and the specific ferry filter
         var topic = "/hfp/v2/journey/ongoing/vp/ferry/1019";
         var filters = new String[]{"/hfp/v2/journey/#", "/hfp/v2/journey/ongoing/+/ferry/#",
                 "/hfp/v2/journey/ongoing/+/metro/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
-        // then
-        assertThat(result).hasValue("/hfp/v2/journey/#");
+        // then - should return both matching filters, not just the first one
+        assertThat(result).containsExactly("/hfp/v2/journey/#", "/hfp/v2/journey/ongoing/+/ferry/#");
     }
 
     @Test
@@ -131,7 +132,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/ferry/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -144,7 +145,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/ferry/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -157,7 +158,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/+/+/+/7280/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -170,7 +171,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"gtfsrt/dev/fi/hsl/tu"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -183,7 +184,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -196,37 +197,37 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/+/bus/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/+/bus/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/+/bus/#");
     }
 
     @Test
-    void shouldMatchApcTopicSpecifically() {
-        // given
+    void shouldMatchAllApplicableFiltersForApcTopic() {
+        // given - APC topic matches both specific APC filter and general journey filter
         var topic = "/hfp/v2/journey/ongoing/apc/bus/0055/01234/2107/1/Tapiola";
         var filters = new String[]{"/hfp/v2/journey/ongoing/apc/#", "/hfp/v2/journey/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/ongoing/apc/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/ongoing/apc/#", "/hfp/v2/journey/#");
     }
 
     @Test
-    void shouldMatchComplexBusTopic() {
-        // given
+    void shouldMatchOnlyApplicableFiltersForBusTopic() {
+        // given - bus topic matches journey filter but not APC or ferry filters
         var topic = "/hfp/v2/journey/ongoing/vp/bus/0022/01216/2107/1/Tapiola/11:06/2265203/5/60;24/18/80/57";
         var filters = new String[]{"/hfp/v2/journey/ongoing/apc/#", "/hfp/v2/journey/ongoing/+/ferry/#",
                 "/hfp/v2/journey/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("/hfp/v2/journey/#");
+        assertThat(result).containsExactly("/hfp/v2/journey/#");
     }
 
     @Test
@@ -236,7 +237,7 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"/hfp/v2/journey/ongoing/vp/#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
         assertThat(result).isEmpty();
@@ -249,9 +250,23 @@ class MqttTopicFilterMatcherTest {
         var filters = new String[]{"#"};
 
         // when
-        var result = MqttTopicFilterMatcher.findMatchingTopicFilter(topic, filters);
+        var result = findMatchingTopicFilters(topic, filters);
 
         // then
-        assertThat(result).hasValue("#");
+        assertThat(result).containsExactly("#");
+    }
+
+    @Test
+    void shouldMatchRoute7280WithBothGeneralAndSpecificFilters() {
+        // given - route 7280 topic matches both the general journey filter and the specific route filter
+        var topic = "/hfp/v2/journey/ongoing/vp/bus/0022/01216/7280/1/Tapiola/11:06/2265203";
+        var filters = new String[]{"/hfp/v2/journey/#", "/hfp/v2/journey/ongoing/+/ferry/#",
+                "/hfp/v2/journey/ongoing/+/metro/#", "/hfp/v2/journey/ongoing/+/+/+/+/7280/#"};
+
+        // when
+        var result = findMatchingTopicFilters(topic, filters);
+
+        // then
+        assertThat(result).containsExactly("/hfp/v2/journey/#", "/hfp/v2/journey/ongoing/+/+/+/+/7280/#");
     }
 }


### PR DESCRIPTION
**Problem**
With topic filters configured as:
"/hfp/v2/journey/#",
"/hfp/v2/journey/ongoing/+/ferry/#",
"/hfp/v2/journey/ongoing/+/metro/#",
"/hfp/v2/journey/ongoing/+/+/+/+/7280/#"

All messages were being counted under /hfp/v2/journey/# because it matched first. Ferry, metro, and route 7280 specific metrics were always zero.